### PR TITLE
Syntax and tab change to example to run under python3

### DIFF
--- a/example/__init__.py
+++ b/example/__init__.py
@@ -5,12 +5,12 @@ def very_inefficient(recursion, accumulator):
         accumulator = accumulator + ('f' * 1024 + '\n')
         very_inefficient(recursion - 1, accumulator)
     else:
-        some_str = ' ' * (10 ** 9 / 4)
+        some_str = ' ' * int(10 ** 9 / 4)
         return accumulator
 
 
 def example_handler(event, context):
     result = very_inefficient(512, '')
     if hasattr(context, 'function_name'):
-	print("Function name is: ", context.function_name)
+       print("Function name is: ", context.function_name)
     return event['key1']  # echo first key value


### PR DESCRIPTION
Compatible change to allow install of emulambda and example to run with python3.

* fixed tab, converted to spaces
* explicit int() cast for   ' ' * float

Install with

`pip3 install emulambda`

Test example now runs.

Prior error:
```

  File "/home/dlee/git.repo/emulambda/example/__init__.py", line 8, in very_inefficient
    some_str = ' ' * (10 * 9 / 4)
TypeError: can't multiply sequence by non-int of type 'float'
EMULAMBDA: LAMBDA ERROR

```